### PR TITLE
possible fix for "TypeError"

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -685,7 +685,7 @@ class downloader:
 
         if self.k_fav_posts:
             try:
-                self.get_favorites('kemono.party', 'post', retry=self.retry)
+                self.get_favorites('kemono.party', 'post')
             except:
                 logger.exception("Unable to get favorite posts from kemono.party")
         if self.c_fav_posts:


### PR DESCRIPTION
#6 

Possible fix for "TypeError: get_favorites() got an unexpected keyword argument 'retry'". I don't know if it breaks something important.

